### PR TITLE
Use stdint for portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ toolsets.
 Notes
 -----
 
-tinf requires int to be at least 32-bit.
-
 The inflate algorithm and data format are from 'DEFLATE Compressed Data
 Format Specification version 1.3' ([RFC 1951][deflate]).
 

--- a/examples/tgunzip/tgunzip.c
+++ b/examples/tgunzip/tgunzip.c
@@ -24,17 +24,18 @@
  */
 
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 
 #include "tinf.h"
 
-static unsigned int read_le32(const unsigned char *p)
+static uint32_t read_le32(const unsigned char *p)
 {
-	return ((unsigned int) p[0])
-	     | ((unsigned int) p[1] << 8)
-	     | ((unsigned int) p[2] << 16)
-	     | ((unsigned int) p[3] << 24);
+	return ((uint32_t) p[0])
+	     | ((uint32_t) p[1] << 8)
+	     | ((uint32_t) p[2] << 16)
+	     | ((uint32_t) p[3] << 24);
 }
 
 static void printf_error(const char *fmt, ...)
@@ -56,9 +57,9 @@ int main(int argc, char *argv[])
 	FILE *fout = NULL;
 	unsigned char *source = NULL;
 	unsigned char *dest = NULL;
-	unsigned int len, dlen, outlen;
-	int retval = EXIT_FAILURE;
-	int res;
+	uint32_t len, dlen, outlen;
+	int32_t retval = EXIT_FAILURE;
+	int32_t res;
 
 	printf("tgunzip " TINF_VER_STRING " - example from the tiny inflate library (www.ibsensoftware.com)\n\n");
 

--- a/src/adler32.c
+++ b/src/adler32.c
@@ -33,16 +33,16 @@
 #define A32_BASE 65521
 #define A32_NMAX 5552
 
-unsigned int tinf_adler32(const void *data, unsigned int length)
+uint32_t tinf_adler32(const void *data, uint32_t length)
 {
 	const unsigned char *buf = (const unsigned char *) data;
 
-	unsigned int s1 = 1;
-	unsigned int s2 = 0;
+	uint32_t s1 = 1;
+	uint32_t s2 = 0;
 
 	while (length > 0) {
-		int k = length < A32_NMAX ? length : A32_NMAX;
-		int i;
+		int32_t k = length < A32_NMAX ? length : A32_NMAX;
+		int32_t i;
 
 		for (i = k / 16; i; --i, buf += 16) {
 			s1 += buf[0];

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -30,18 +30,18 @@
 
 #include "tinf.h"
 
-static const unsigned int tinf_crc32tab[16] = {
+static const uint32_t tinf_crc32tab[16] = {
 	0x00000000, 0x1DB71064, 0x3B6E20C8, 0x26D930AC, 0x76DC4190,
 	0x6B6B51F4, 0x4DB26158, 0x5005713C, 0xEDB88320, 0xF00F9344,
 	0xD6D6A3E8, 0xCB61B38C, 0x9B64C2B0, 0x86D3D2D4, 0xA00AE278,
 	0xBDBDF21C
 };
 
-unsigned int tinf_crc32(const void *data, unsigned int length)
+uint32_t tinf_crc32(const void *data, uint32_t length)
 {
 	const unsigned char *buf = (const unsigned char *) data;
-	unsigned int crc = 0xFFFFFFFF;
-	unsigned int i;
+	uint32_t crc = 0xFFFFFFFF;
+	uint32_t i;
 
 	if (length == 0) {
 		return 0;

--- a/src/tinf.h
+++ b/src/tinf.h
@@ -26,6 +26,8 @@
 #ifndef TINF_H_INCLUDED
 #define TINF_H_INCLUDED
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -76,8 +78,8 @@ void TINFCC tinf_init(void);
  * @param sourceLen size of compressed data
  * @return `TINF_OK` on success, error code on error
  */
-int TINFCC tinf_uncompress(void *dest, unsigned int *destLen,
-                           const void *source, unsigned int sourceLen);
+int32_t TINFCC tinf_uncompress(void *dest, uint32_t *destLen,
+                           const void *source, uint32_t sourceLen);
 
 /**
  * Decompress `sourceLen` bytes of gzip data from `source` to `dest`.
@@ -94,8 +96,8 @@ int TINFCC tinf_uncompress(void *dest, unsigned int *destLen,
  * @param sourceLen size of compressed data
  * @return `TINF_OK` on success, error code on error
  */
-int TINFCC tinf_gzip_uncompress(void *dest, unsigned int *destLen,
-                                const void *source, unsigned int sourceLen);
+int32_t TINFCC tinf_gzip_uncompress(void *dest, uint32_t *destLen,
+                                const void *source, uint32_t sourceLen);
 
 /**
  * Decompress `sourceLen` bytes of zlib data from `source` to `dest`.
@@ -112,8 +114,8 @@ int TINFCC tinf_gzip_uncompress(void *dest, unsigned int *destLen,
  * @param sourceLen size of compressed data
  * @return `TINF_OK` on success, error code on error
  */
-int TINFCC tinf_zlib_uncompress(void *dest, unsigned int *destLen,
-                                const void *source, unsigned int sourceLen);
+int32_t TINFCC tinf_zlib_uncompress(void *dest, uint32_t *destLen,
+                                const void *source, uint32_t sourceLen);
 
 /**
  * Compute Adler-32 checksum of `length` bytes starting at `data`.
@@ -122,7 +124,7 @@ int TINFCC tinf_zlib_uncompress(void *dest, unsigned int *destLen,
  * @param length size of data
  * @return Adler-32 checksum
  */
-unsigned int TINFCC tinf_adler32(const void *data, unsigned int length);
+uint32_t TINFCC tinf_adler32(const void *data, uint32_t length);
 
 /**
  * Compute CRC32 checksum of `length` bytes starting at `data`.
@@ -131,7 +133,7 @@ unsigned int TINFCC tinf_adler32(const void *data, unsigned int length);
  * @param length size of data
  * @return CRC32 checksum
  */
-unsigned int TINFCC tinf_crc32(const void *data, unsigned int length);
+uint32_t TINFCC tinf_crc32(const void *data, uint32_t length);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/tinfgzip.c
+++ b/src/tinfgzip.c
@@ -33,28 +33,28 @@ typedef enum {
 	FCOMMENT = 16
 } tinf_gzip_flag;
 
-static unsigned int read_le16(const unsigned char *p)
+static uint32_t read_le16(const unsigned char *p)
 {
-	return ((unsigned int) p[0])
-	     | ((unsigned int) p[1] << 8);
+	return ((uint32_t) p[0])
+	     | ((uint32_t) p[1] << 8);
 }
 
-static unsigned int read_le32(const unsigned char *p)
+static uint32_t read_le32(const unsigned char *p)
 {
-	return ((unsigned int) p[0])
-	     | ((unsigned int) p[1] << 8)
-	     | ((unsigned int) p[2] << 16)
-	     | ((unsigned int) p[3] << 24);
+	return ((uint32_t) p[0])
+	     | ((uint32_t) p[1] << 8)
+	     | ((uint32_t) p[2] << 16)
+	     | ((uint32_t) p[3] << 24);
 }
 
-int tinf_gzip_uncompress(void *dest, unsigned int *destLen,
-                         const void *source, unsigned int sourceLen)
+int32_t tinf_gzip_uncompress(void *dest, uint32_t *destLen,
+                         const void *source, uint32_t sourceLen)
 {
 	const unsigned char *src = (const unsigned char *) source;
 	unsigned char *dst = (unsigned char *) dest;
 	const unsigned char *start;
-	unsigned int dlen, crc32;
-	int res;
+	uint32_t dlen, crc32;
+	int32_t res;
 	unsigned char flg;
 
 	/* -- Check header -- */
@@ -89,7 +89,7 @@ int tinf_gzip_uncompress(void *dest, unsigned int *destLen,
 
 	/* Skip extra data if present */
 	if (flg & FEXTRA) {
-		unsigned int xlen = read_le16(start);
+		uint32_t xlen = read_le16(start);
 
 		if (xlen > sourceLen - 12) {
 			return TINF_DATA_ERROR;
@@ -118,7 +118,7 @@ int tinf_gzip_uncompress(void *dest, unsigned int *destLen,
 
 	/* Check header crc if present */
 	if (flg & FHCRC) {
-		unsigned int hcrc;
+		uint32_t hcrc;
 
 		if (start - src > sourceLen - 2) {
 			return TINF_DATA_ERROR;

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -26,26 +26,21 @@
 #include "tinf.h"
 
 #include <assert.h>
-#include <limits.h>
-
-#if defined(UINT_MAX) && (UINT_MAX) < 0xFFFFFFFFUL
-#  error "tinf requires unsigned int to be at least 32-bit"
-#endif
 
 /* -- Internal data structures -- */
 
 struct tinf_tree {
-	unsigned short counts[16]; /* Number of codes with a given length */
-	unsigned short symbols[288]; /* Symbols sorted by code */
-	int max_sym;
+	uint16_t counts[16]; /* Number of codes with a given length */
+	uint16_t symbols[288]; /* Symbols sorted by code */
+	int32_t max_sym;
 };
 
 struct tinf_data {
 	const unsigned char *source;
 	const unsigned char *source_end;
-	unsigned int tag;
-	int bitcount;
-	int overflow;
+	uint32_t tag;
+	int32_t bitcount;
+	int32_t overflow;
 
 	unsigned char *dest_start;
 	unsigned char *dest;
@@ -57,16 +52,16 @@ struct tinf_data {
 
 /* -- Utility functions -- */
 
-static unsigned int read_le16(const unsigned char *p)
+static uint32_t read_le16(const unsigned char *p)
 {
-	return ((unsigned int) p[0])
-	     | ((unsigned int) p[1] << 8);
+	return ((uint32_t) p[0])
+	     | ((uint32_t) p[1] << 8);
 }
 
 /* Build fixed Huffman trees */
 static void tinf_build_fixed_trees(struct tinf_tree *lt, struct tinf_tree *dt)
 {
-	int i;
+	int32_t i;
 
 	/* Build fixed literal/length tree */
 	for (i = 0; i < 16; ++i) {
@@ -107,11 +102,11 @@ static void tinf_build_fixed_trees(struct tinf_tree *lt, struct tinf_tree *dt)
 }
 
 /* Given an array of code lengths, build a tree */
-static int tinf_build_tree(struct tinf_tree *t, const unsigned char *lengths,
-                           unsigned int num)
+static int32_t tinf_build_tree(struct tinf_tree *t, const unsigned char *lengths,
+                           uint32_t num)
 {
-	unsigned short offs[16];
-	unsigned int i, num_codes, available;
+	uint16_t offs[16];
+	uint32_t i, num_codes, available;
 
 	assert(num <= 288);
 
@@ -133,7 +128,7 @@ static int tinf_build_tree(struct tinf_tree *t, const unsigned char *lengths,
 
 	/* Compute offset table for distribution sort */
 	for (available = 1, num_codes = 0, i = 0; i < 16; ++i) {
-		unsigned int used = t->counts[i];
+		uint32_t used = t->counts[i];
 
 		/* Check length contains no more codes than available */
 		if (used > available) {
@@ -175,14 +170,14 @@ static int tinf_build_tree(struct tinf_tree *t, const unsigned char *lengths,
 
 /* -- Decode functions -- */
 
-static void tinf_refill(struct tinf_data *d, int num)
+static void tinf_refill(struct tinf_data *d, int32_t num)
 {
 	assert(num >= 0 && num <= 32);
 
 	/* Read bytes until at least num bits available */
 	while (d->bitcount < num) {
 		if (d->source != d->source_end) {
-			d->tag |= (unsigned int) *d->source++ << d->bitcount;
+			d->tag |= (uint32_t) *d->source++ << d->bitcount;
 		}
 		else {
 			d->overflow = 1;
@@ -193,9 +188,9 @@ static void tinf_refill(struct tinf_data *d, int num)
 	assert(d->bitcount <= 32);
 }
 
-static unsigned int tinf_getbits_no_refill(struct tinf_data *d, int num)
+static uint32_t tinf_getbits_no_refill(struct tinf_data *d, int32_t num)
 {
-	unsigned int bits;
+	uint32_t bits;
 
 	assert(num >= 0 && num <= d->bitcount);
 
@@ -210,23 +205,23 @@ static unsigned int tinf_getbits_no_refill(struct tinf_data *d, int num)
 }
 
 /* Get num bits from source stream */
-static unsigned int tinf_getbits(struct tinf_data *d, int num)
+static uint32_t tinf_getbits(struct tinf_data *d, int32_t num)
 {
 	tinf_refill(d, num);
 	return tinf_getbits_no_refill(d, num);
 }
 
 /* Read a num bit value from stream and add base */
-static unsigned int tinf_getbits_base(struct tinf_data *d, int num, int base)
+static uint32_t tinf_getbits_base(struct tinf_data *d, int32_t num, int32_t base)
 {
 	return base + (num ? tinf_getbits(d, num) : 0);
 }
 
 /* Given a data stream and a tree, decode a symbol */
-static int tinf_decode_symbol(struct tinf_data *d, const struct tinf_tree *t)
+static int32_t tinf_decode_symbol(struct tinf_data *d, const struct tinf_tree *t)
 {
-	int base = 0, offs = 0;
-	int len;
+	int32_t base = 0, offs = 0;
+	int32_t len;
 
 	/*
 	 * Get more bits while code index is above number of codes
@@ -260,7 +255,7 @@ static int tinf_decode_symbol(struct tinf_data *d, const struct tinf_tree *t)
 }
 
 /* Given a data stream, decode dynamic trees from it */
-static int tinf_decode_trees(struct tinf_data *d, struct tinf_tree *lt,
+static int32_t tinf_decode_trees(struct tinf_data *d, struct tinf_tree *lt,
                              struct tinf_tree *dt)
 {
 	unsigned char lengths[288 + 32];
@@ -271,9 +266,9 @@ static int tinf_decode_trees(struct tinf_data *d, struct tinf_tree *lt,
 		11,  4, 12, 3, 13, 2, 14, 1, 15
 	};
 
-	unsigned int hlit, hdist, hclen;
-	unsigned int i, num, length;
-	int res;
+	uint32_t hlit, hdist, hclen;
+	uint32_t i, num, length;
+	int32_t res;
 
 	/* Get 5 bits HLIT (257-286) */
 	hlit = tinf_getbits_base(d, 5, 257);
@@ -304,7 +299,7 @@ static int tinf_decode_trees(struct tinf_data *d, struct tinf_tree *lt,
 	/* Read code lengths for code length alphabet */
 	for (i = 0; i < hclen; ++i) {
 		/* Get 3 bits code length (0-7) */
-		unsigned int clen = tinf_getbits(d, 3);
+		uint32_t clen = tinf_getbits(d, 3);
 
 		lengths[clcidx[i]] = clen;
 	}
@@ -323,7 +318,7 @@ static int tinf_decode_trees(struct tinf_data *d, struct tinf_tree *lt,
 
 	/* Decode code lengths for the dynamic trees */
 	for (num = 0; num < hlit + hdist; ) {
-		int sym = tinf_decode_symbol(d, lt);
+		int32_t sym = tinf_decode_symbol(d, lt);
 
 		if (sym > lt->max_sym) {
 			return TINF_DATA_ERROR;
@@ -387,7 +382,7 @@ static int tinf_decode_trees(struct tinf_data *d, struct tinf_tree *lt,
 /* -- Block inflate functions -- */
 
 /* Given a stream and two trees, inflate a block of data */
-static int tinf_inflate_block_data(struct tinf_data *d, struct tinf_tree *lt,
+static int32_t tinf_inflate_block_data(struct tinf_data *d, struct tinf_tree *lt,
                                    struct tinf_tree *dt)
 {
 	/* Extra bits and base tables for length codes */
@@ -397,7 +392,7 @@ static int tinf_inflate_block_data(struct tinf_data *d, struct tinf_tree *lt,
 		4, 4, 4, 4, 5, 5, 5, 5, 0, 127
 	};
 
-	static const unsigned short length_base[30] = {
+	static const uint16_t length_base[30] = {
 		 3,  4,  5,   6,   7,   8,   9,  10,  11,  13,
 		15, 17, 19,  23,  27,  31,  35,  43,  51,  59,
 		67, 83, 99, 115, 131, 163, 195, 227, 258,   0
@@ -410,14 +405,14 @@ static int tinf_inflate_block_data(struct tinf_data *d, struct tinf_tree *lt,
 		9, 9, 10, 10, 11, 11, 12, 12, 13, 13
 	};
 
-	static const unsigned short dist_base[30] = {
+	static const uint16_t dist_base[30] = {
 		   1,    2,    3,    4,    5,    7,    9,    13,    17,    25,
 		  33,   49,   65,   97,  129,  193,  257,   385,   513,   769,
 		1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577
 	};
 
 	for (;;) {
-		int sym = tinf_decode_symbol(d, lt);
+		int32_t sym = tinf_decode_symbol(d, lt);
 
 		/* Check for overflow in bit reader */
 		if (d->overflow) {
@@ -431,8 +426,8 @@ static int tinf_inflate_block_data(struct tinf_data *d, struct tinf_tree *lt,
 			*d->dest++ = sym;
 		}
 		else {
-			int length, dist, offs;
-			int i;
+			int32_t length, dist, offs;
+			int32_t i;
 
 			/* Check for end of block */
 			if (sym == 256) {
@@ -480,9 +475,9 @@ static int tinf_inflate_block_data(struct tinf_data *d, struct tinf_tree *lt,
 }
 
 /* Inflate an uncompressed block of data */
-static int tinf_inflate_uncompressed_block(struct tinf_data *d)
+static int32_t tinf_inflate_uncompressed_block(struct tinf_data *d)
 {
-	unsigned int length, invlength;
+	uint32_t length, invlength;
 
 	if (d->source_end - d->source < 4) {
 		return TINF_DATA_ERROR;
@@ -522,7 +517,7 @@ static int tinf_inflate_uncompressed_block(struct tinf_data *d)
 }
 
 /* Inflate a block of data compressed with fixed Huffman trees */
-static int tinf_inflate_fixed_block(struct tinf_data *d)
+static int32_t tinf_inflate_fixed_block(struct tinf_data *d)
 {
 	/* Build fixed Huffman trees */
 	tinf_build_fixed_trees(&d->ltree, &d->dtree);
@@ -532,10 +527,10 @@ static int tinf_inflate_fixed_block(struct tinf_data *d)
 }
 
 /* Inflate a block of data compressed with dynamic Huffman trees */
-static int tinf_inflate_dynamic_block(struct tinf_data *d)
+static int32_t tinf_inflate_dynamic_block(struct tinf_data *d)
 {
 	/* Decode trees from stream */
-	int res = tinf_decode_trees(d, &d->ltree, &d->dtree);
+	int32_t res = tinf_decode_trees(d, &d->ltree, &d->dtree);
 
 	if (res != TINF_OK) {
 		return res;
@@ -554,11 +549,11 @@ void tinf_init(void)
 }
 
 /* Inflate stream from source to dest */
-int tinf_uncompress(void *dest, unsigned int *destLen,
-                    const void *source, unsigned int sourceLen)
+int32_t tinf_uncompress(void *dest, uint32_t *destLen,
+                    const void *source, uint32_t sourceLen)
 {
 	struct tinf_data d;
-	int bfinal;
+	int32_t bfinal;
 
 	/* Initialise data */
 	d.source = (const unsigned char *) source;
@@ -572,8 +567,8 @@ int tinf_uncompress(void *dest, unsigned int *destLen,
 	d.dest_end = d.dest + *destLen;
 
 	do {
-		unsigned int btype;
-		int res;
+		uint32_t btype;
+		int32_t res;
 
 		/* Read final block flag */
 		bfinal = tinf_getbits(&d, 1);
@@ -625,11 +620,11 @@ int tinf_uncompress(void *dest, unsigned int *destLen,
 
 unsigned char depacked[64 * 1024];
 
-extern int
+extern int32_t
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
 	if (size > UINT_MAX / 2) { return 0; }
-	unsigned int destLen = sizeof(depacked);
+	uint32_t destLen = sizeof(depacked);
 	tinf_uncompress(depacked, &destLen, data, size);
 	return 0;
 }

--- a/src/tinfzlib.c
+++ b/src/tinfzlib.c
@@ -25,21 +25,21 @@
 
 #include "tinf.h"
 
-static unsigned int read_be32(const unsigned char *p)
+static uint32_t read_be32(const unsigned char *p)
 {
-	return ((unsigned int) p[0] << 24)
-	     | ((unsigned int) p[1] << 16)
-	     | ((unsigned int) p[2] << 8)
-	     | ((unsigned int) p[3]);
+	return ((uint32_t) p[0] << 24)
+	     | ((uint32_t) p[1] << 16)
+	     | ((uint32_t) p[2] << 8)
+	     | ((uint32_t) p[3]);
 }
 
-int tinf_zlib_uncompress(void *dest, unsigned int *destLen,
-                         const void *source, unsigned int sourceLen)
+int32_t tinf_zlib_uncompress(void *dest, uint32_t *destLen,
+                         const void *source, uint32_t sourceLen)
 {
 	const unsigned char *src = (const unsigned char *) source;
 	unsigned char *dst = (unsigned char *) dest;
-	unsigned int a32;
-	int res;
+	uint32_t a32;
+	int32_t res;
 	unsigned char cmf, flg;
 
 	/* -- Check header -- */

--- a/test/greatest.h
+++ b/test/greatest.h
@@ -68,7 +68,7 @@ SUITE(suite) {
 GREATEST_MAIN_DEFS();
 
 /* Set up, run suite(s) of tests, report pass/fail/skip stats. */
-int run_tests(void) {
+int32_t run_tests(void) {
     GREATEST_INIT();            /* init. greatest internals */
     /* List of suites to run (if any). */
     RUN_SUITE(suite);
@@ -159,10 +159,10 @@ int main(int argc, char **argv) {
 
 /* Info for the current running suite. */
 typedef struct greatest_suite_info {
-    unsigned int tests_run;
-    unsigned int passed;
-    unsigned int failed;
-    unsigned int skipped;
+    uint32_t tests_run;
+    uint32_t passed;
+    uint32_t failed;
+    uint32_t skipped;
 
 #if GREATEST_USE_TIME
     /* timers, pre/post running suite and individual tests */
@@ -184,12 +184,12 @@ typedef void greatest_teardown_cb(void *udata);
 /* Type for an equality comparison between two pointers of the same type.
  * Should return non-0 if equal, otherwise 0.
  * UDATA is a closure value, passed through from ASSERT_EQUAL_T[m]. */
-typedef int greatest_equal_cb(const void *expd, const void *got, void *udata);
+typedef int32_t greatest_equal_cb(const void *expd, const void *got, void *udata);
 
 /* Type for a callback that prints a value pointed to by T.
  * Return value has the same meaning as printf's.
  * UDATA is a closure value, passed through from ASSERT_EQUAL_T[m]. */
-typedef int greatest_printf_cb(const void *t, void *udata);
+typedef int32_t greatest_printf_cb(const void *t, void *udata);
 
 /* Callbacks for an arbitrary type; needed for type-specific
  * comparisons via GREATEST_ASSERT_EQUAL_T[m].*/
@@ -235,20 +235,20 @@ typedef struct greatest_run_info {
     unsigned char running_test; /* guard for nested RUN_TEST calls */
     unsigned char exact_name_match;
 
-    unsigned int tests_run;     /* total test count */
+    uint32_t tests_run;     /* total test count */
 
     /* currently running test suite */
     greatest_suite_info suite;
 
     /* overall pass/fail/skip counts */
-    unsigned int passed;
-    unsigned int failed;
-    unsigned int skipped;
-    unsigned int assertions;
+    uint32_t passed;
+    uint32_t failed;
+    uint32_t skipped;
+    uint32_t assertions;
 
     /* info to print about the most recent failure */
-    unsigned int fail_line;
-    unsigned int pad_1;
+    uint32_t fail_line;
+    uint32_t pad_1;
     const char *fail_file;
     const char *msg;
 
@@ -259,8 +259,8 @@ typedef struct greatest_run_info {
     void *teardown_udata;
 
     /* formatting info for ".....s...F"-style output */
-    unsigned int col;
-    unsigned int width;
+    uint32_t col;
+    uint32_t width;
 
     /* only run a specific suite or test */
     const char *suite_filter;
@@ -278,7 +278,7 @@ typedef struct greatest_run_info {
 #endif
 
 #if GREATEST_USE_LONGJMP
-    int pad_jmp_buf;
+    int32_t pad_jmp_buf;
     unsigned char pad_2[4];
     jmp_buf jump_dest;
 #endif
@@ -286,10 +286,10 @@ typedef struct greatest_run_info {
 
 struct greatest_report_t {
     /* overall pass/fail/skip counts */
-    unsigned int passed;
-    unsigned int failed;
-    unsigned int skipped;
-    unsigned int assertions;
+    uint32_t passed;
+    uint32_t failed;
+    uint32_t skipped;
+    uint32_t assertions;
 };
 
 /* Global var for the current testing context.
@@ -297,7 +297,7 @@ struct greatest_report_t {
 extern greatest_run_info greatest_info;
 
 /* Type for ASSERT_ENUM_EQ's ENUM_STR argument. */
-typedef const char *greatest_enum_str_fun(int value);
+typedef const char *greatest_enum_str_fun(int32_t value);
 
 
 /**********************
@@ -305,20 +305,20 @@ typedef const char *greatest_enum_str_fun(int value);
  **********************/
 
 /* These are used internally by greatest macros. */
-int greatest_test_pre(const char *name);
-void greatest_test_post(int res);
-int greatest_do_assert_equal_t(const void *expd, const void *got,
+int32_t greatest_test_pre(const char *name);
+void greatest_test_post(int32_t res);
+int32_t greatest_do_assert_equal_t(const void *expd, const void *got,
     greatest_type_info *type_info, void *udata);
-void greatest_prng_init_first_pass(int id);
-int greatest_prng_init_second_pass(int id, unsigned long seed);
-void greatest_prng_step(int id);
+void greatest_prng_init_first_pass(int32_t id);
+int32_t greatest_prng_init_second_pass(int32_t id, unsigned long seed);
+void greatest_prng_step(int32_t id);
 
 /* These are part of the public greatest API. */
 void GREATEST_SET_SETUP_CB(greatest_setup_cb *cb, void *udata);
 void GREATEST_SET_TEARDOWN_CB(greatest_teardown_cb *cb, void *udata);
 void GREATEST_INIT(void);
 void GREATEST_PRINT_REPORT(void);
-int greatest_all_passed(void);
+int32_t greatest_all_passed(void);
 void greatest_set_suite_filter(const char *filter);
 void greatest_set_test_filter(const char *filter);
 void greatest_set_test_exclude(const char *filter);
@@ -327,8 +327,8 @@ void greatest_stop_at_first_fail(void);
 void greatest_abort_on_fail(void);
 void greatest_list_only(void);
 void greatest_get_report(struct greatest_report_t *report);
-unsigned int greatest_get_verbosity(void);
-void greatest_set_verbosity(unsigned int verbosity);
+uint32_t greatest_get_verbosity(void);
+void greatest_set_verbosity(uint32_t verbosity);
 void greatest_set_flag(greatest_flag_t flag);
 void greatest_set_test_suffix(const char *suffix);
 
@@ -519,8 +519,8 @@ typedef enum greatest_test_res {
 /* Fail if EXP is not equal to GOT, printing enum IDs. */
 #define GREATEST_ASSERT_ENUM_EQm(MSG, EXP, GOT, ENUM_STR)               \
     do {                                                                \
-        int greatest_EXP = (int)(EXP);                                  \
-        int greatest_GOT = (int)(GOT);                                  \
+        int32_t greatest_EXP = (int32_t)(EXP);                                  \
+        int32_t greatest_GOT = (int32_t)(GOT);                                  \
         greatest_enum_str_fun *greatest_ENUM_STR = ENUM_STR;            \
         if (greatest_EXP != greatest_GOT) {                             \
             GREATEST_FPRINTF(GREATEST_STDOUT, "\nExpected: %s",         \
@@ -651,7 +651,7 @@ typedef enum greatest_test_res {
 
 #define GREATEST_CLOCK_DIFF(C1, C2)                                     \
     GREATEST_FPRINTF(GREATEST_STDOUT, " (%lu ticks, %.3f sec)",         \
-        (long unsigned int) (C2) - (long unsigned int)(C1),             \
+        (long uint32_t) (C2) - (long uint32_t)(C1),             \
         (double)((C2) - (C1)) / (1.0 * (double)CLOCKS_PER_SEC))
 #else
 #define GREATEST_SET_TIME(UNUSED)
@@ -704,8 +704,8 @@ typedef enum greatest_test_res {
 #define GREATEST_MAIN_DEFS()                                            \
                                                                         \
 /* Is FILTER a subset of NAME? */                                       \
-static int greatest_name_match(const char *name, const char *filter,    \
-        int res_if_none) {                                              \
+static int32_t greatest_name_match(const char *name, const char *filter,    \
+        int32_t res_if_none) {                                              \
     size_t offset = 0;                                                  \
     size_t filter_len = filter ? strlen(filter) : 0;                    \
     if (filter_len == 0) { return res_if_none; } /* no filter */        \
@@ -737,9 +737,9 @@ static void greatest_buffer_test_name(const char *name) {               \
                                                                         \
 /* Before running a test, check the name filtering and                  \
  * test shuffling state, if applicable, and then call setup hooks. */   \
-int greatest_test_pre(const char *name) {                               \
+int32_t greatest_test_pre(const char *name) {                               \
     struct greatest_run_info *g = &greatest_info;                       \
-    int match;                                                          \
+    int32_t match;                                                          \
     greatest_buffer_test_name(name);                                    \
     match = greatest_name_match(g->name_buf, g->test_filter, 1) &&      \
       !greatest_name_match(g->name_buf, g->test_exclude, 0);            \
@@ -816,7 +816,7 @@ static void greatest_do_skip(void) {                                    \
     g->suite.skipped++;                                                 \
 }                                                                       \
                                                                         \
-void greatest_test_post(int res) {                                      \
+void greatest_test_post(int32_t res) {                                      \
     GREATEST_SET_TIME(greatest_info.suite.post_test);                   \
     if (greatest_info.teardown) {                                       \
         void *udata = greatest_info.teardown_udata;                     \
@@ -873,7 +873,7 @@ static void update_counts_and_reset_suite(void) {                       \
     greatest_info.col = 0;                                              \
 }                                                                       \
                                                                         \
-static int greatest_suite_pre(const char *suite_name) {                 \
+static int32_t greatest_suite_pre(const char *suite_name) {                 \
     struct greatest_prng *p = &greatest_info.prng[0];                   \
     if (!greatest_name_match(suite_name, greatest_info.suite_filter, 1) \
         || (GREATEST_FAILURE_ABORT())) { return 0; }                    \
@@ -903,9 +903,9 @@ static void greatest_run_suite(greatest_suite_cb *suite_cb,             \
     }                                                                   \
 }                                                                       \
                                                                         \
-int greatest_do_assert_equal_t(const void *expd, const void *got,       \
+int32_t greatest_do_assert_equal_t(const void *expd, const void *got,       \
         greatest_type_info *type_info, void *udata) {                   \
-    int eq = 0;                                                         \
+    int32_t eq = 0;                                                         \
     if (type_info == NULL || type_info->equal == NULL) { return 0; }    \
     eq = type_info->equal(expd, got, udata);                            \
     if (!eq) {                                                          \
@@ -935,8 +935,8 @@ static void greatest_usage(const char *name) {                          \
         name);                                                          \
 }                                                                       \
                                                                         \
-static void greatest_parse_options(int argc, char **argv) {             \
-    int i = 0;                                                          \
+static void greatest_parse_options(int32_t argc, char **argv) {             \
+    int32_t i = 0;                                                          \
     for (i = 1; i < argc; i++) {                                        \
         if (argv[i][0] == '-') {                                        \
             char f = argv[i][1];                                        \
@@ -978,7 +978,7 @@ static void greatest_parse_options(int argc, char **argv) {             \
     }                                                                   \
 }                                                                       \
                                                                         \
-int greatest_all_passed(void) { return (greatest_info.failed == 0); }   \
+int32_t greatest_all_passed(void) { return (greatest_info.failed == 0); }   \
                                                                         \
 void greatest_set_test_filter(const char *filter) {                     \
     greatest_info.test_filter = filter;                                 \
@@ -1017,11 +1017,11 @@ void greatest_get_report(struct greatest_report_t *report) {            \
     }                                                                   \
 }                                                                       \
                                                                         \
-unsigned int greatest_get_verbosity(void) {                             \
+uint32_t greatest_get_verbosity(void) {                             \
     return greatest_info.verbosity;                                     \
 }                                                                       \
                                                                         \
-void greatest_set_verbosity(unsigned int verbosity) {                   \
+void greatest_set_verbosity(uint32_t verbosity) {                   \
     greatest_info.verbosity = (unsigned char)verbosity;                 \
 }                                                                       \
                                                                         \
@@ -1043,7 +1043,7 @@ void GREATEST_SET_TEARDOWN_CB(greatest_teardown_cb *cb, void *udata) {  \
     greatest_info.teardown_udata = udata;                               \
 }                                                                       \
                                                                         \
-static int greatest_string_equal_cb(const void *expd, const void *got,  \
+static int32_t greatest_string_equal_cb(const void *expd, const void *got,  \
     void *udata) {                                                      \
     size_t *size = (size_t *)udata;                                     \
     return (size != NULL                                                \
@@ -1051,7 +1051,7 @@ static int greatest_string_equal_cb(const void *expd, const void *got,  \
         : (0 == strcmp((const char *)expd, (const char *)got)));        \
 }                                                                       \
                                                                         \
-static int greatest_string_printf_cb(const void *t, void *udata) {      \
+static int32_t greatest_string_printf_cb(const void *t, void *udata) {      \
     (void)udata; /* note: does not check \0 termination. */             \
     return GREATEST_FPRINTF(GREATEST_STDOUT, "%s", (const char *)t);    \
 }                                                                       \
@@ -1060,20 +1060,20 @@ greatest_type_info greatest_type_info_string = {                        \
     greatest_string_equal_cb, greatest_string_printf_cb,                \
 };                                                                      \
                                                                         \
-static int greatest_memory_equal_cb(const void *expd, const void *got,  \
+static int32_t greatest_memory_equal_cb(const void *expd, const void *got,  \
     void *udata) {                                                      \
     greatest_memory_cmp_env *env = (greatest_memory_cmp_env *)udata;    \
     return (0 == memcmp(expd, got, env->size));                         \
 }                                                                       \
                                                                         \
 /* Hexdump raw memory, with differences highlighted */                  \
-static int greatest_memory_printf_cb(const void *t, void *udata) {      \
+static int32_t greatest_memory_printf_cb(const void *t, void *udata) {      \
     greatest_memory_cmp_env *env = (greatest_memory_cmp_env *)udata;    \
     const unsigned char *buf = (const unsigned char *)t;                \
     unsigned char diff_mark = ' ';                                      \
     FILE *out = GREATEST_STDOUT;                                        \
     size_t i, line_i, line_len = 0;                                     \
-    int len = 0;   /* format hexdump with differences highlighted */    \
+    int32_t len = 0;   /* format hexdump with differences highlighted */    \
     for (i = 0; i < env->size; i+= line_len) {                          \
         diff_mark = ' ';                                                \
         line_len = env->size - i;                                       \
@@ -1082,9 +1082,9 @@ static int greatest_memory_printf_cb(const void *t, void *udata) {      \
             if (env->exp[line_i] != env->got[line_i]) diff_mark = 'X';  \
         }                                                               \
         len += GREATEST_FPRINTF(out, "\n%04x %c ",                      \
-            (unsigned int)i, diff_mark);                                \
+            (uint32_t)i, diff_mark);                                \
         for (line_i = i; line_i < i + line_len; line_i++) {             \
-            int m = env->exp[line_i] == env->got[line_i]; /* match? */  \
+            int32_t m = env->exp[line_i] == env->got[line_i]; /* match? */  \
             len += GREATEST_FPRINTF(out, "%02x%c",                      \
                 buf[line_i], m ? ' ' : '<');                            \
         }                                                               \
@@ -1101,12 +1101,12 @@ static int greatest_memory_printf_cb(const void *t, void *udata) {      \
     return len;                                                         \
 }                                                                       \
                                                                         \
-void greatest_prng_init_first_pass(int id) {                            \
+void greatest_prng_init_first_pass(int32_t id) {                            \
     greatest_info.prng[id].random_order = 1;                            \
     greatest_info.prng[id].count_run = 0;                               \
 }                                                                       \
                                                                         \
-int greatest_prng_init_second_pass(int id, unsigned long seed) {        \
+int32_t greatest_prng_init_second_pass(int32_t id, unsigned long seed) {        \
     struct greatest_prng *p = &greatest_info.prng[id];                  \
     if (p->count == 0) { return 0; }                                    \
     p->count_ceil = p->count;                                           \
@@ -1131,7 +1131,7 @@ int greatest_prng_init_second_pass(int id, unsigned long seed) {        \
  * with a starting position chosen based on the initial seed.           \
  * For details, see: Knuth, The Art of Computer Programming             \
  * Volume. 2, section 3.2.1. */                                         \
-void greatest_prng_step(int id) {                                       \
+void greatest_prng_step(int32_t id) {                                       \
     struct greatest_prng *p = &greatest_info.prng[id];                  \
     do {                                                                \
         p->state = ((p->a * p->state) + p->c) & (p->m - 1);             \

--- a/test/test_tinf.c
+++ b/test/test_tinf.c
@@ -26,6 +26,7 @@
 #include "tinf.h"
 
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <time.h>
 
@@ -40,8 +41,8 @@ static const unsigned char robuffer[] = { 0 };
 static unsigned char buffer[4096];
 
 struct packed_data {
-	unsigned int src_size;
-	unsigned int depacked_size;
+	uint32_t src_size;
+	uint32_t depacked_size;
 	const unsigned char data[32];
 };
 
@@ -179,8 +180,8 @@ TEST inflate_padding(void)
 	static const unsigned char data[] = {
 		0x03, 0xFC
 	};
-	unsigned int dlen = 0;
-	int res;
+	uint32_t dlen = 0;
+	int32_t res;
 
 	res = tinf_uncompress((void *) robuffer, &dlen, data, ARRAY_SIZE(data));
 
@@ -203,8 +204,8 @@ TEST inflate_empty_no_literals(void)
 		0x05, 0xCA, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0xFF,
 		0x6B, 0x01, 0x00
 	};
-	unsigned int dlen = 0;
-	int res;
+	uint32_t dlen = 0;
+	int32_t res;
 
 	res = tinf_uncompress((void *) robuffer, &dlen, data, ARRAY_SIZE(data));
 
@@ -224,8 +225,8 @@ TEST inflate_huffman_only(void)
 		0x00, 0x00, 0x00, 0x00, 0x02
 	};
 	unsigned char out[256];
-	unsigned int dlen = ARRAY_SIZE(out);
-	int res;
+	uint32_t dlen = ARRAY_SIZE(out);
+	int32_t res;
 	size_t i;
 
 	memset(out, 0xFF, ARRAY_SIZE(out));
@@ -251,8 +252,8 @@ TEST inflate_rle(void)
 		0xA9, 0x07, 0x39, 0x73, 0x01
 	};
 	unsigned char out[256];
-	unsigned int dlen = ARRAY_SIZE(out);
-	int res;
+	uint32_t dlen = ARRAY_SIZE(out);
+	int32_t res;
 	size_t i;
 
 	memset(out, 0xFF, ARRAY_SIZE(out));
@@ -278,8 +279,8 @@ TEST inflate_max_matchlen(void)
 		0xA9, 0x17, 0xB9, 0x00, 0x2C
 	};
 	unsigned char out[259];
-	unsigned int dlen = ARRAY_SIZE(out);
-	int res;
+	uint32_t dlen = ARRAY_SIZE(out);
+	int32_t res;
 	size_t i;
 
 	memset(out, 0xFF, ARRAY_SIZE(out));
@@ -311,8 +312,8 @@ TEST inflate_max_matchlen_alt(void)
 		0xA9, 0x07, 0xB9, 0x00, 0xFC, 0x05
 	};
 	unsigned char out[259];
-	unsigned int dlen = ARRAY_SIZE(out);
-	int res;
+	uint32_t dlen = ARRAY_SIZE(out);
+	int32_t res;
 	size_t i;
 
 	memset(out, 0xFF, ARRAY_SIZE(out));
@@ -342,8 +343,8 @@ TEST inflate_max_matchdist(void)
 		0xFE, 0xFF, 0x05
 	};
 	unsigned char out[32771];
-	unsigned int dlen = ARRAY_SIZE(out);
-	int res;
+	uint32_t dlen = ARRAY_SIZE(out);
+	int32_t res;
 	size_t i;
 
 	memset(out, 0xFF, ARRAY_SIZE(out));
@@ -375,8 +376,8 @@ TEST inflate_code_length_codes(void)
 		0x77, 0x1E, 0xCA, 0x61, 0x01
 	};
 	unsigned char out[4];
-	unsigned int dlen = ARRAY_SIZE(out);
-	int res;
+	uint32_t dlen = ARRAY_SIZE(out);
+	int32_t res;
 	size_t i;
 
 	memset(out, 0xFF, ARRAY_SIZE(out));
@@ -404,8 +405,8 @@ TEST inflate_max_codelen(void)
 		0xFF, 0xFE, 0xDF, 0xFF, 0xF7, 0xFF, 0xFB, 0xFF, 0x03
 	};
 	unsigned char out[15];
-	unsigned int dlen = ARRAY_SIZE(out);
-	int res;
+	uint32_t dlen = ARRAY_SIZE(out);
+	int32_t res;
 	size_t i;
 
 	memset(out, 0xFF, ARRAY_SIZE(out));
@@ -427,10 +428,10 @@ TEST inflate_max_codelen(void)
 TEST inflate_random(void)
 {
 	unsigned char data[256];
-	unsigned int len;
+	uint32_t len;
 
 	for (len = 1; len < ARRAY_SIZE(data); ++len) {
-		unsigned int dlen = ARRAY_SIZE(buffer);
+		uint32_t dlen = ARRAY_SIZE(buffer);
 		size_t i;
 
 		for (i = 0; i < len; ++i) {
@@ -452,9 +453,9 @@ TEST inflate_random(void)
 TEST inflate_error_case(const void *closure)
 {
 	const struct packed_data *pd = (const struct packed_data *) closure;
-	int res;
+	int32_t res;
 
-	unsigned int size = pd->depacked_size;
+	uint32_t size = pd->depacked_size;
 	res = tinf_uncompress(buffer, &size, pd->data, pd->src_size);
 
 	ASSERT(res != TINF_OK);
@@ -480,7 +481,7 @@ SUITE(tinflate)
 	RUN_TEST(inflate_random);
 
 	for (i = 0; i < ARRAY_SIZE(inflate_errors); ++i) {
-		sprintf(suffix, "%d", (int) i);
+		sprintf(suffix, "%d", (int32_t) i);
 		greatest_set_test_suffix(suffix);
 		RUN_TEST1(inflate_error_case, &inflate_errors[i]);
 	}
@@ -495,8 +496,8 @@ TEST zlib_empty_raw(void)
 		0x78, 0x9C, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x00,
 		0x01
 	};
-	unsigned int dlen = 0;
-	int res;
+	uint32_t dlen = 0;
+	int32_t res;
 
 	res = tinf_zlib_uncompress((void *) robuffer, &dlen, data, ARRAY_SIZE(data));
 
@@ -511,8 +512,8 @@ TEST zlib_empty_fixed(void)
 	static const unsigned char data[] = {
 		0x78, 0x9C, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01
 	};
-	unsigned int dlen = 0;
-	int res;
+	uint32_t dlen = 0;
+	int32_t res;
 
 	res = tinf_zlib_uncompress((void *) robuffer, &dlen, data, ARRAY_SIZE(data));
 
@@ -528,8 +529,8 @@ TEST zlib_empty_dynamic(void)
 		0x78, 0x9C, 0x05, 0xC1, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x10, 0xFF, 0xD5, 0x08, 0x00, 0x00, 0x00, 0x01
 	};
-	unsigned int dlen = 0;
-	int res;
+	uint32_t dlen = 0;
+	int32_t res;
 
 	res = tinf_zlib_uncompress((void *) robuffer, &dlen, data, ARRAY_SIZE(data));
 
@@ -546,8 +547,8 @@ TEST zlib_onebyte_raw(void)
 		0x00, 0x01
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_zlib_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -563,8 +564,8 @@ TEST zlib_onebyte_fixed(void)
 		0x78, 0x9C, 0x63, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_zlib_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -581,8 +582,8 @@ TEST zlib_onebyte_dynamic(void)
 		0x10, 0xFF, 0xD5, 0x10, 0x00, 0x01, 0x00, 0x01
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_zlib_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -599,8 +600,8 @@ TEST zlib_zeroes(void)
 		0x00, 0x01
 	};
 	unsigned char out[256];
-	unsigned int dlen = ARRAY_SIZE(out);
-	int res;
+	uint32_t dlen = ARRAY_SIZE(out);
+	int32_t res;
 	size_t i;
 
 	memset(out, 0xFF, ARRAY_SIZE(out));
@@ -622,9 +623,9 @@ TEST zlib_zeroes(void)
 TEST zlib_error_case(const void *closure)
 {
 	const struct packed_data *pd = (const struct packed_data *) closure;
-	int res;
+	int32_t res;
 
-	unsigned int size = pd->depacked_size;
+	uint32_t size = pd->depacked_size;
 	res = tinf_zlib_uncompress(buffer, &size, pd->data, pd->src_size);
 
 	ASSERT(res != TINF_OK);
@@ -647,7 +648,7 @@ SUITE(tinfzlib)
 	RUN_TEST(zlib_zeroes);
 
 	for (i = 0; i < ARRAY_SIZE(zlib_errors); ++i) {
-		sprintf(suffix, "%d", (int) i);
+		sprintf(suffix, "%d", (int32_t) i);
 		greatest_set_test_suffix(suffix);
 		RUN_TEST1(zlib_error_case, &zlib_errors[i]);
 	}
@@ -663,8 +664,8 @@ TEST gzip_empty_raw(void)
 		0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00
 	};
-	unsigned int dlen = 0;
-	int res;
+	uint32_t dlen = 0;
+	int32_t res;
 
 	res = tinf_gzip_uncompress((void *) robuffer, &dlen, data, ARRAY_SIZE(data));
 
@@ -680,8 +681,8 @@ TEST gzip_empty_fixed(void)
 		0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x0B,
 		0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	};
-	unsigned int dlen = 0;
-	int res;
+	uint32_t dlen = 0;
+	int32_t res;
 
 	res = tinf_gzip_uncompress((void *) robuffer, &dlen, data, ARRAY_SIZE(data));
 
@@ -698,8 +699,8 @@ TEST gzip_empty_dynamic(void)
 		0x05, 0xC1, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0xFF,
 		0xD5, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	};
-	unsigned int dlen = 0;
-	int res;
+	uint32_t dlen = 0;
+	int32_t res;
 
 	res = tinf_gzip_uncompress((void *) robuffer, &dlen, data, ARRAY_SIZE(data));
 
@@ -717,8 +718,8 @@ TEST gzip_onebyte_raw(void)
 		0x01, 0x00, 0x00, 0x00
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_gzip_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -736,8 +737,8 @@ TEST gzip_onebyte_fixed(void)
 		0x00
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_gzip_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -755,8 +756,8 @@ TEST gzip_onebyte_dynamic(void)
 		0xD5, 0x10, 0x8D, 0xEF, 0x02, 0xD2, 0x01, 0x00, 0x00, 0x00
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_gzip_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -774,8 +775,8 @@ TEST gzip_fhcrc(void)
 		0x02, 0xD2, 0x01, 0x00, 0x00, 0x00
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_gzip_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -793,8 +794,8 @@ TEST gzip_fextra(void)
 		0xFF, 0x00, 0x8D, 0xEF, 0x02, 0xD2, 0x01, 0x00, 0x00, 0x00
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_gzip_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -812,8 +813,8 @@ TEST gzip_fname(void)
 		0xFF, 0x00, 0x8D, 0xEF, 0x02, 0xD2, 0x01, 0x00, 0x00, 0x00
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_gzip_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -831,8 +832,8 @@ TEST gzip_fcomment(void)
 		0xFF, 0x00, 0x8D, 0xEF, 0x02, 0xD2, 0x01, 0x00, 0x00, 0x00
 	};
 	unsigned char out[] = { 0xFF };
-	unsigned int dlen = 1;
-	int res;
+	uint32_t dlen = 1;
+	int32_t res;
 
 	res = tinf_gzip_uncompress(out, &dlen, data, ARRAY_SIZE(data));
 
@@ -845,9 +846,9 @@ TEST gzip_fcomment(void)
 TEST gzip_error_case(const void *closure)
 {
 	const struct packed_data *pd = (const struct packed_data *) closure;
-	int res;
+	int32_t res;
 
-	unsigned int size = pd->depacked_size;
+	uint32_t size = pd->depacked_size;
 	res = tinf_gzip_uncompress(buffer, &size, pd->data, pd->src_size);
 
 	ASSERT(res != TINF_OK);
@@ -874,7 +875,7 @@ SUITE(tinfgzip)
 	RUN_TEST(gzip_fcomment);
 
 	for (i = 0; i < ARRAY_SIZE(gzip_errors); ++i) {
-		sprintf(suffix, "%d", (int) i);
+		sprintf(suffix, "%d", (int32_t) i);
 		greatest_set_test_suffix(suffix);
 		RUN_TEST1(gzip_error_case, &gzip_errors[i]);
 	}

--- a/tools/mkzdata.c
+++ b/tools/mkzdata.c
@@ -32,7 +32,7 @@
 struct lsb_bitwriter {
 	unsigned char *next_out;
 	uint32_t tag;
-	int bitcount;
+	int32_t bitcount;
 };
 
 static void
@@ -57,7 +57,7 @@ lbw_finalize(struct lsb_bitwriter *lbw)
 }
 
 static void
-lbw_flush(struct lsb_bitwriter *lbw, int num) {
+lbw_flush(struct lsb_bitwriter *lbw, int32_t num) {
 	assert(num >= 0 && num <= 32);
 
 	/* Write bytes until at least num bits free */
@@ -71,7 +71,7 @@ lbw_flush(struct lsb_bitwriter *lbw, int num) {
 }
 
 static void
-lbw_putbits_no_flush(struct lsb_bitwriter *lbw, uint32_t bits, int num) {
+lbw_putbits_no_flush(struct lsb_bitwriter *lbw, uint32_t bits, int32_t num) {
 	assert(num >= 0 && num <= 32 - lbw->bitcount);
 	assert((bits & (~0ULL << num)) == 0);
 
@@ -81,13 +81,13 @@ lbw_putbits_no_flush(struct lsb_bitwriter *lbw, uint32_t bits, int num) {
 }
 
 static void
-lbw_putbits(struct lsb_bitwriter *lbw, uint32_t bits, int num) {
+lbw_putbits(struct lsb_bitwriter *lbw, uint32_t bits, int32_t num) {
 	lbw_flush(lbw, num);
 	lbw_putbits_no_flush(lbw, bits, num);
 }
 
 static void
-lbw_putbits_rev(struct lsb_bitwriter *lbw, uint32_t bits, int num) {
+lbw_putbits_rev(struct lsb_bitwriter *lbw, uint32_t bits, int32_t num) {
 	lbw_flush(lbw, num);
 	while (num-- > 0) {
 		lbw_putbits_no_flush(lbw, (bits >> num) & 1, 1);
@@ -217,7 +217,7 @@ write_256_huffman(struct lsb_bitwriter *lbw)
 	lbw_putbits(lbw, 0, 7);
 
 	// compressed data
-	for (int i = 0; i < 256; ++i) {
+	for (int32_t i = 0; i < 256; ++i) {
 		lbw_putbits_rev(lbw, 0, 1); // 00 byte
 	}
 
@@ -359,7 +359,7 @@ write_max_dist(struct lsb_bitwriter *lbw)
 
 	lbw_putbits_rev(lbw, 0, 1); // distance 1
 
-	for (int i = 0; i < 126; ++i) {
+	for (int32_t i = 0; i < 126; ++i) {
 		lbw_putbits_rev(lbw, 0, 1); // 285 = copy len 258
 
 		lbw_putbits_rev(lbw, 0, 1); // distance 1
@@ -485,7 +485,7 @@ main(int argc, char *argv[])
 
 	uint32_t size = lbw_finalize(&lbw) - &data[0];
 
-	for (int i = 0; i < size; ++i) {
+	for (int32_t i = 0; i < size; ++i) {
 		if (i > 0) {
 			fputs(", ", stdout);
 		}
@@ -504,8 +504,8 @@ main(int argc, char *argv[])
 
 		fwrite(data, 1, size, fout);
 
-		unsigned int dsize = sizeof(buffer);
-		int res = tinf_uncompress(buffer, &dsize, data, size);
+		uint32_t dsize = sizeof(buffer);
+		int32_t res = tinf_uncompress(buffer, &dsize, data, size);
 
 		if (res != TINF_OK) {
 			fputs("mkzdata: decompression error\n", stderr);


### PR DESCRIPTION
I haven't tested this extensively, but I've run a find-replace to use stdint everywhere. This should hopefully fix the portability concerns, and not require that int be 32 bits.

I'm not sure how to kick off the CI process.